### PR TITLE
Add offline Flask audit management skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+audit.db
+*.pyc
+instance/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "manage.py"]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
-# About tport
+# Audit Tool
 
-Tport is a Multi Threaded Port Scanner designed in python. It helps to scan open ports of an IP. Tport uses the python module threading to make port scan faster. This tool is still in its development phase , many features are yet to be added. 
+A self-hosted security audit management system implemented with Python and Flask.
+The application runs fully offline and provides role based access control, audit
+tracking and simple reporting.
 
-# Installation 
-           git clone https://github.com/roger737/tport.git
+## Features
+- Flask backend with Blueprints
+- Role based access control via custom decorators
+- Audit lifecycle management with comments, findings and attachments
+- SQLite database by default (PostgreSQL via `DATABASE_URL`)
+- Session based authentication using Flask-Login
+- CSV/PDF export of audits
+- Docker and docker-compose for local deployment
 
+## Usage
+```
+python seed.py   # initialise database with admin user (admin/admin)
+python manage.py # run the development server
+```
 
-# Usage
+Then navigate to `http://localhost:5000` and log in with the seeded credentials.
 
-Tport has 4 scan modes:
-            
-            Mode 1: Scans all common ports from 1 to 1024
-            Mode 2: Scans ports in the range of 1 to 49152
-            Mode 3: Scans basic common ports like 20, 21, 22, 23, 25, 53, 80, 110, 443
-            Mode 4: Scans custom ports specified by a user
-            
-            
-# Version
-
-The current version is 1.0
+This project is intentionally JavaScript free so it can operate in restricted
+environments.

--- a/audit_tool/__init__.py
+++ b/audit_tool/__init__.py
@@ -1,0 +1,60 @@
+import os
+import logging
+from pathlib import Path
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+
+# Initialize extensions
+
+db = SQLAlchemy()
+login_manager = LoginManager()
+login_manager.login_view = 'auth.login'
+
+
+def create_app(test_config: dict | None = None) -> Flask:
+    """Application factory.
+
+    The application is configured to use SQLite by default so it can run
+    fully offline.  A ``DATABASE_URL`` environment variable may be supplied
+    to use a different backend such as PostgreSQL.
+    """
+    app = Flask(__name__, instance_relative_config=True)
+    upload_dir = Path(app.instance_path) / 'uploads'
+    app.config.from_mapping(
+        SECRET_KEY='dev',
+        SQLALCHEMY_DATABASE_URI=os.environ.get('DATABASE_URL', 'sqlite:///audit.db'),
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        UPLOAD_FOLDER=str(upload_dir),
+    )
+    if test_config:
+        app.config.update(test_config)
+
+    db.init_app(app)
+    login_manager.init_app(app)
+
+    # Ensure instance folders exist for uploads and logging
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    log_file = Path(app.instance_path) / 'audit.log'
+    logging.basicConfig(
+        filename=log_file,
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s: %(message)s'
+    )
+
+    # Import and register blueprints lazily to avoid circular imports
+    from .auth import auth_bp
+    from .audits import audit_bp
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(audit_bp)
+
+    @app.route('/')
+    def index():
+        from flask_login import current_user
+        if current_user.is_authenticated:
+            return "Welcome {}".format(current_user.username)
+        return "Welcome to the Audit Tool"
+
+    return app

--- a/audit_tool/ai.py
+++ b/audit_tool/ai.py
@@ -1,0 +1,17 @@
+"""Optional offline AI helpers.
+
+This module is intentionally lightweight.  If an offline model such as
+`llama.cpp` is available, the functions below can call into it to provide
+classification suggestions or remediation advice.
+"""
+from typing import Optional
+
+
+def suggest_classification(description: str) -> Optional[str]:
+    """Return a naive classification suggestion based on keywords."""
+    description = description.lower()
+    if 'sql' in description:
+        return 'Injection'
+    if 'xss' in description:
+        return 'Cross Site Scripting'
+    return None

--- a/audit_tool/audits.py
+++ b/audit_tool/audits.py
@@ -1,0 +1,204 @@
+from flask import Blueprint, render_template, redirect, url_for, Response, request, current_app, send_from_directory
+from flask_login import login_required, current_user
+from flask_wtf import FlaskForm
+from flask_wtf.file import FileField, FileAllowed
+from wtforms import StringField, TextAreaField, SelectField, SubmitField
+from wtforms.validators import DataRequired
+
+from .models import Audit, RiskTag, Comment, Attachment, AuditLog, Finding, db
+from .rbac import permission_required
+import os
+
+
+class AuditForm(FlaskForm):
+    title = StringField('Title', validators=[DataRequired()])
+    description = TextAreaField('Description')
+    severity = SelectField('Severity', choices=['Low', 'Medium', 'High', 'Critical'])
+    source = SelectField('Source', choices=['Internal', 'External'])
+    assigned_team = StringField('Assigned Team')
+    risks = StringField('Risk Tags (comma separated)')
+    submit = SubmitField('Create')
+
+
+class CommentForm(FlaskForm):
+    content = TextAreaField('Comment', validators=[DataRequired()])
+    submit = SubmitField('Add Comment')
+
+
+class StatusForm(FlaskForm):
+    status = SelectField('Status', choices=['Open', 'Verified', 'Mitigated', 'Closed'])
+    submit = SubmitField('Update')
+
+
+class AttachmentForm(FlaskForm):
+    file = FileField('Attachment', validators=[FileAllowed(['pdf', 'txt', 'csv', 'png', 'jpg', 'jpeg'])])
+    submit = SubmitField('Upload')
+
+
+class FindingForm(FlaskForm):
+    title = StringField('Title', validators=[DataRequired()])
+    description = TextAreaField('Description')
+    severity = SelectField('Severity', choices=['Low', 'Medium', 'High', 'Critical'])
+    status = SelectField('Status', choices=['Open', 'Verified', 'Mitigated', 'Closed'])
+    submit = SubmitField('Add Finding')
+
+
+audit_bp = Blueprint('audit', __name__, url_prefix='/audit', template_folder='templates')
+
+
+@audit_bp.route('/dashboard')
+@login_required
+@permission_required('view_audit')
+def dashboard():
+    severity = request.args.get('severity')
+    risk = request.args.get('risk')
+    query = Audit.query
+    if severity:
+        query = query.filter_by(severity=severity)
+    if risk:
+        query = query.join(Audit.risks).filter(RiskTag.name == risk)
+    audits = query.all()
+    risks = RiskTag.query.all()
+    return render_template('audits/list.html', audits=audits, risks=risks)
+
+
+@audit_bp.route('/create', methods=['GET', 'POST'])
+@login_required
+@permission_required('create_audit')
+def create():
+    form = AuditForm()
+    if form.validate_on_submit():
+        audit = Audit(
+            title=form.title.data,
+            description=form.description.data,
+            severity=form.severity.data,
+            source=form.source.data,
+            assigned_team=form.assigned_team.data,
+        )
+        # handle risk tags
+        tag_names = [n.strip() for n in form.risks.data.split(',') if n.strip()]
+        for name in tag_names:
+            tag = RiskTag.query.filter_by(name=name).first()
+            if not tag:
+                tag = RiskTag(name=name)
+            audit.risks.append(tag)
+        db.session.add(audit)
+        db.session.commit()
+        log = AuditLog(audit=audit, user=current_user, action='Created audit')
+        db.session.add(log)
+        db.session.commit()
+        return redirect(url_for('audit.detail', audit_id=audit.id))
+    return render_template('audits/create.html', form=form)
+
+
+@audit_bp.route('/<int:audit_id>', methods=['GET', 'POST'])
+@login_required
+@permission_required('view_audit')
+def detail(audit_id: int):
+    audit = Audit.query.get_or_404(audit_id)
+    comment_form = CommentForm(prefix='comment')
+    status_form = StatusForm(prefix='status')
+    if not status_form.status.data:
+        status_form.status.data = audit.status
+    attach_form = AttachmentForm(prefix='attach')
+    finding_form = FindingForm(prefix='finding')
+    can_edit = current_user.has_permission('edit_audit')
+
+    if comment_form.submit.data and can_edit and comment_form.validate_on_submit():
+        c = Comment(audit=audit, user=current_user, content=comment_form.content.data)
+        db.session.add(c)
+        db.session.add(AuditLog(audit=audit, user=current_user, action='Added comment'))
+        db.session.commit()
+        return redirect(url_for('audit.detail', audit_id=audit_id))
+
+    if status_form.submit.data and can_edit and status_form.validate_on_submit():
+        audit.status = status_form.status.data
+        db.session.add(AuditLog(audit=audit, user=current_user, action=f'Status changed to {audit.status}'))
+        db.session.commit()
+        return redirect(url_for('audit.detail', audit_id=audit_id))
+
+    if attach_form.submit.data and can_edit and attach_form.validate_on_submit() and attach_form.file.data:
+        file = attach_form.file.data
+        filename = file.filename
+        path = os.path.join(current_app.config['UPLOAD_FOLDER'], filename)
+        file.save(path)
+        att = Attachment(audit=audit, filename=filename)
+        db.session.add(att)
+        db.session.add(AuditLog(audit=audit, user=current_user, action=f'Uploaded {filename}'))
+        db.session.commit()
+        return redirect(url_for('audit.detail', audit_id=audit_id))
+
+    if finding_form.submit.data and can_edit and finding_form.validate_on_submit():
+        f = Finding(
+            audit=audit,
+            title=finding_form.title.data,
+            description=finding_form.description.data,
+            severity=finding_form.severity.data,
+            status=finding_form.status.data,
+        )
+        db.session.add(f)
+        db.session.add(AuditLog(audit=audit, user=current_user, action='Added finding'))
+        db.session.commit()
+        return redirect(url_for('audit.detail', audit_id=audit_id))
+
+    return render_template(
+        'audits/detail.html',
+        audit=audit,
+        comment_form=comment_form,
+        status_form=status_form,
+        attach_form=attach_form,
+        finding_form=finding_form,
+        can_edit=can_edit,
+    )
+
+
+@audit_bp.route('/attachment/<int:attachment_id>')
+@login_required
+@permission_required('view_audit')
+def attachment(attachment_id: int):
+    att = Attachment.query.get_or_404(attachment_id)
+    return send_from_directory(current_app.config['UPLOAD_FOLDER'], att.filename, as_attachment=True)
+
+
+@audit_bp.route('/export/csv')
+@login_required
+@permission_required('view_audit')
+def export_csv():
+    """Export all audits to a CSV file."""
+    import csv
+    from io import StringIO
+
+    si = StringIO()
+    writer = csv.writer(si)
+    writer.writerow(['id', 'title', 'severity', 'status'])
+    for a in Audit.query.all():
+        writer.writerow([a.id, a.title, a.severity, a.status])
+    output = si.getvalue()
+    return Response(output, mimetype='text/csv', headers={'Content-Disposition': 'attachment;filename=audits.csv'})
+
+
+@audit_bp.route('/export/pdf')
+@login_required
+@permission_required('view_audit')
+def export_pdf():
+    """Export all audits to a simple PDF report."""
+    from io import BytesIO
+    from reportlab.lib.pagesizes import letter
+    from reportlab.pdfgen import canvas
+
+    buffer = BytesIO()
+    p = canvas.Canvas(buffer, pagesize=letter)
+    text = p.beginText(40, 750)
+    text.textLine('Audit Report')
+    text.textLine('')
+    for a in Audit.query.all():
+        text.textLine(f"{a.id}: {a.title} - {a.severity} - {a.status}")
+    p.drawText(text)
+    p.showPage()
+    p.save()
+    buffer.seek(0)
+    return Response(
+        buffer.read(),
+        mimetype='application/pdf',
+        headers={'Content-Disposition': 'attachment;filename=audits.pdf'},
+    )

--- a/audit_tool/auth.py
+++ b/audit_tool/auth.py
@@ -1,0 +1,36 @@
+from flask import Blueprint, render_template, redirect, url_for, flash
+from flask_login import login_user, logout_user, login_required
+from flask_wtf import FlaskForm
+from wtforms import StringField, PasswordField, SubmitField
+from wtforms.validators import DataRequired
+
+from .models import User
+from . import db
+
+
+class LoginForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired()])
+    password = PasswordField('Password', validators=[DataRequired()])
+    submit = SubmitField('Login')
+
+
+auth_bp = Blueprint('auth', __name__, template_folder='templates')
+
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    form = LoginForm()
+    if form.validate_on_submit():
+        user = User.query.filter_by(username=form.username.data).first()
+        if user and user.check_password(form.password.data):
+            login_user(user)
+            return redirect(url_for('audit.dashboard'))
+        flash('Invalid credentials', 'danger')
+    return render_template('login.html', form=form)
+
+
+@auth_bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('auth.login'))

--- a/audit_tool/models.py
+++ b/audit_tool/models.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+from datetime import datetime
+from werkzeug.security import generate_password_hash, check_password_hash
+from flask_login import UserMixin
+from sqlalchemy import Table, Column, Integer, String, ForeignKey, Text, DateTime
+from sqlalchemy.orm import relationship
+
+from . import db, login_manager
+
+# Association tables
+roles_permissions = Table(
+    'roles_permissions',
+    db.metadata,
+    Column('role_id', Integer, ForeignKey('role.id')),
+    Column('permission_id', Integer, ForeignKey('permission.id')),
+)
+
+user_roles = Table(
+    'user_roles',
+    db.metadata,
+    Column('user_id', Integer, ForeignKey('user.id')),
+    Column('role_id', Integer, ForeignKey('role.id')),
+)
+
+audit_risks = Table(
+    'audit_risks',
+    db.metadata,
+    Column('audit_id', Integer, ForeignKey('audit.id')),
+    Column('risk_id', Integer, ForeignKey('risk_tag.id')),
+)
+
+
+class Permission(db.Model):
+    id = Column(Integer, primary_key=True)
+    name = Column(String(64), unique=True, nullable=False)
+
+
+class Role(db.Model):
+    id = Column(Integer, primary_key=True)
+    name = Column(String(64), unique=True, nullable=False)
+    permissions = relationship('Permission', secondary=roles_permissions, backref='roles')
+
+
+class User(UserMixin, db.Model):
+    id = Column(Integer, primary_key=True)
+    username = Column(String(64), unique=True, nullable=False)
+    password_hash = Column(String(128), nullable=False)
+    roles = relationship('Role', secondary=user_roles, backref='users')
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)
+
+    def has_permission(self, name: str) -> bool:
+        return any(name == p.name for r in self.roles for p in r.permissions)
+
+
+@login_manager.user_loader
+def load_user(user_id: str) -> User | None:
+    return User.query.get(int(user_id))
+
+
+class Audit(db.Model):
+    id = Column(Integer, primary_key=True)
+    title = Column(String(128), nullable=False)
+    description = Column(Text)
+    severity = Column(String(32))
+    source = Column(String(32))
+    assigned_team = Column(String(64))
+    status = Column(String(32), default='Open')
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    risks = relationship('RiskTag', secondary=audit_risks, backref='audits')
+    comments = relationship('Comment', backref='audit', cascade='all,delete')
+    findings = relationship('Finding', backref='audit', cascade='all,delete')
+    attachments = relationship('Attachment', backref='audit', cascade='all,delete')
+    logs = relationship('AuditLog', backref='audit', cascade='all,delete')
+
+
+class RiskTag(db.Model):
+    id = Column(Integer, primary_key=True)
+    name = Column(String(64), unique=True, nullable=False)
+
+
+class Comment(db.Model):
+    id = Column(Integer, primary_key=True)
+    audit_id = Column(Integer, ForeignKey('audit.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('user.id'), nullable=False)
+    content = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    user = relationship('User')
+
+
+class Attachment(db.Model):
+    id = Column(Integer, primary_key=True)
+    audit_id = Column(Integer, ForeignKey('audit.id'), nullable=False)
+    filename = Column(String(256), nullable=False)
+    uploaded_at = Column(DateTime, default=datetime.utcnow)
+
+
+class AuditLog(db.Model):
+    id = Column(Integer, primary_key=True)
+    audit_id = Column(Integer, ForeignKey('audit.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('user.id'), nullable=False)
+    action = Column(String(256), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    user = relationship('User')
+
+
+class Finding(db.Model):
+    id = Column(Integer, primary_key=True)
+    audit_id = Column(Integer, ForeignKey('audit.id'), nullable=False)
+    title = Column(String(128), nullable=False)
+    description = Column(Text)
+    severity = Column(String(32))
+    status = Column(String(32), default='Open')
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/audit_tool/rbac.py
+++ b/audit_tool/rbac.py
@@ -1,0 +1,15 @@
+from functools import wraps
+from flask import abort
+from flask_login import current_user
+
+
+def permission_required(name: str):
+    """Decorator to ensure the current user has a given permission."""
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if not current_user.is_authenticated or not current_user.has_permission(name):
+                abort(403)
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/audit_tool/static/style.css
+++ b/audit_tool/static/style.css
@@ -1,0 +1,104 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #f4f6f8;
+  color: #333;
+}
+
+nav {
+  background: #2c3e50;
+  color: #fff;
+  padding: 1em 2em;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+nav a {
+  color: #fff;
+  margin-right: 1em;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+.container {
+  width: 90%;
+  max-width: 1000px;
+  margin: 2em auto;
+}
+
+.card {
+  background: #fff;
+  padding: 1.5em;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  margin-bottom: 1.5em;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 0.5em 0.75em;
+  border-bottom: 1px solid #ddd;
+}
+
+th {
+  background: #f0f0f0;
+  text-align: left;
+}
+
+form .form-group {
+  margin-bottom: 1em;
+}
+
+form label {
+  display: block;
+  margin-bottom: 0.25em;
+  font-weight: bold;
+}
+
+form input[type=text], form select, form textarea, form input[type=password], form input[type=file] {
+  width: 100%;
+  padding: 0.5em;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+button, input[type=submit], .btn {
+  background: #2c3e50;
+  color: #fff;
+  border: none;
+  padding: 0.5em 1em;
+  border-radius: 4px;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+}
+
+button:hover, input[type=submit]:hover, .btn:hover {
+  background: #1a242f;
+}
+
+.flash {
+  padding: 0.75em 1em;
+  border-radius: 4px;
+  margin-bottom: 1em;
+}
+
+.flash-success {
+  background: #d4edda;
+  color: #155724;
+}
+
+.flash-error {
+  background: #f8d7da;
+  color: #721c24;
+}

--- a/audit_tool/templates/audits/create.html
+++ b/audit_tool/templates/audits/create.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="card">
+  <h2>Create Audit</h2>
+  <form method="post">
+    {{ form.hidden_tag() }}
+    <div class="form-group">{{ form.title.label }} {{ form.title() }}</div>
+    <div class="form-group">{{ form.description.label }} {{ form.description() }}</div>
+    <div class="form-group">{{ form.severity.label }} {{ form.severity() }}</div>
+    <div class="form-group">{{ form.source.label }} {{ form.source() }}</div>
+    <div class="form-group">{{ form.assigned_team.label }} {{ form.assigned_team() }}</div>
+    <div class="form-group">{{ form.risks.label }} {{ form.risks() }}</div>
+    {{ form.submit() }}
+  </form>
+</div>
+{% endblock %}

--- a/audit_tool/templates/audits/detail.html
+++ b/audit_tool/templates/audits/detail.html
@@ -1,0 +1,69 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="card">
+  <h2>Audit {{ audit.id }} - {{ audit.title }}</h2>
+  <p>{{ audit.description }}</p>
+  <p>Severity: {{ audit.severity }} | Status: {{ audit.status }} | Source: {{ audit.source }} | Assigned: {{ audit.assigned_team }}</p>
+
+  {% if can_edit %}
+  <h3>Update Status</h3>
+  <form method="post">
+    {{ status_form.hidden_tag() }}
+    <div class="form-group">{{ status_form.status.label }} {{ status_form.status() }}</div>
+    {{ status_form.submit() }}
+  </form>
+
+  <h3>Add Comment</h3>
+  <form method="post">
+    {{ comment_form.hidden_tag() }}
+    <div class="form-group">{{ comment_form.content.label }} {{ comment_form.content(rows=3) }}</div>
+    {{ comment_form.submit() }}
+  </form>
+
+  <h3>Add Finding</h3>
+  <form method="post">
+    {{ finding_form.hidden_tag() }}
+    <div class="form-group">{{ finding_form.title.label }} {{ finding_form.title() }}</div>
+    <div class="form-group">{{ finding_form.description.label }} {{ finding_form.description(rows=3) }}</div>
+    <div class="form-group">{{ finding_form.severity.label }} {{ finding_form.severity() }}</div>
+    <div class="form-group">{{ finding_form.status.label }} {{ finding_form.status() }}</div>
+    {{ finding_form.submit() }}
+  </form>
+
+  <h3>Upload Attachment</h3>
+  <form method="post" enctype="multipart/form-data">
+    {{ attach_form.hidden_tag() }}
+    <div class="form-group">{{ attach_form.file.label }} {{ attach_form.file() }}</div>
+    {{ attach_form.submit() }}
+  </form>
+  {% endif %}
+
+  <h3>Findings</h3>
+  <ul>
+    {% for f in audit.findings %}
+      <li>{{ f.title }} - {{ f.severity }} - {{ f.status }}</li>
+    {% endfor %}
+  </ul>
+
+  <h3>Attachments</h3>
+  <ul>
+    {% for a in audit.attachments %}
+      <li><a href="/audit/attachment/{{ a.id }}">{{ a.filename }}</a></li>
+    {% endfor %}
+  </ul>
+
+  <h3>Comments</h3>
+  <ul>
+    {% for c in audit.comments %}
+      <li>{{ c.user.username }} ({{ c.created_at }}): {{ c.content }}</li>
+    {% endfor %}
+  </ul>
+
+  <h3>Audit Log</h3>
+  <ul>
+    {% for l in audit.logs %}
+      <li>{{ l.created_at }} - {{ l.user.username }}: {{ l.action }}</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/audit_tool/templates/audits/list.html
+++ b/audit_tool/templates/audits/list.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="card">
+  <h2>Audits</h2>
+  <a class="btn" href="/audit/create">Create Audit</a>
+
+  <form method="get">
+    <div class="form-group">
+      <label>Severity
+        <select name="severity">
+          <option value="">All</option>
+          {% for s in ['Low','Medium','High','Critical'] %}
+            <option value="{{ s }}" {% if request.args.severity==s %}selected{% endif %}>{{ s }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
+    <div class="form-group">
+      <label>Risk
+        <select name="risk">
+          <option value="">All</option>
+          {% for r in risks %}
+            <option value="{{ r.name }}" {% if request.args.risk==r.name %}selected{% endif %}>{{ r.name }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
+    <button type="submit">Filter</button>
+  </form>
+
+  <table>
+    <tr><th>ID</th><th>Title</th><th>Severity</th><th>Status</th></tr>
+    {% for audit in audits %}
+      <tr>
+        <td>{{ audit.id }}</td>
+        <td><a href="/audit/{{ audit.id }}">{{ audit.title }}</a></td>
+        <td>{{ audit.severity }}</td>
+        <td>{{ audit.status }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+</div>
+{% endblock %}

--- a/audit_tool/templates/base.html
+++ b/audit_tool/templates/base.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Audit Tool</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <nav>
+    <div class="nav-left"><a href="/audit/dashboard">Audit Tool</a></div>
+    <div class="nav-right">
+    {% if current_user.is_authenticated %}
+      <a href="/audit/dashboard">Dashboard</a>
+      <a href="/logout">Logout</a>
+    {% else %}
+      <a href="/login">Login</a>
+    {% endif %}
+    </div>
+  </nav>
+  <div class="container">
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash flash-{{ category }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+  {% block content %}{% endblock %}
+  </div>
+</body>
+</html>

--- a/audit_tool/templates/login.html
+++ b/audit_tool/templates/login.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="card">
+  <h2>Login</h2>
+  <form method="post">
+    {{ form.hidden_tag() }}
+    <div class="form-group">{{ form.username.label }} {{ form.username() }}</div>
+    <div class="form-group">{{ form.password.label }} {{ form.password() }}</div>
+    {{ form.submit() }}
+  </form>
+</div>
+{% endblock %}

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,29 @@
+"""Simple CLI utilities for offline maintenance tasks."""
+import argparse
+import csv
+from audit_tool import create_app, db
+from audit_tool.models import Audit
+
+
+def export_csv(path: str) -> None:
+    app = create_app()
+    with app.app_context():
+        rows = Audit.query.all()
+        with open(path, 'w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow(['id', 'title', 'severity', 'status'])
+            for a in rows:
+                writer.writerow([a.id, a.title, a.severity, a.status])
+    print(f'Exported {len(rows)} audits to {path}')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Audit tool maintenance CLI')
+    parser.add_argument('--export', metavar='PATH', help='Export audits to CSV')
+    args = parser.parse_args()
+    if args.export:
+        export_csv(args.export)
+
+
+if __name__ == '__main__':
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    ports:
+      - "5000:5000"
+    depends_on:
+      - db
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: audit
+      POSTGRES_PASSWORD: audit
+      POSTGRES_DB: audit
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  # ai service can be added here when an offline model is available
+volumes:
+  db_data:

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,6 @@
+from audit_tool import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+Flask-SQLAlchemy
+Flask-Login
+Flask-WTF
+reportlab
+pandas

--- a/seed.py
+++ b/seed.py
@@ -1,0 +1,49 @@
+"""Populate the database with default roles, permissions and an admin user."""
+from audit_tool import create_app, db
+from audit_tool.models import Role, Permission, User, RiskTag
+
+app = create_app()
+
+with app.app_context():
+    db.create_all()
+
+    # Permissions
+    perms = ['view_audit', 'create_audit', 'edit_audit']
+    permission_objs = []
+    for name in perms:
+        p = Permission.query.filter_by(name=name).first()
+        if not p:
+            p = Permission(name=name)
+            db.session.add(p)
+        permission_objs.append(p)
+
+    # Roles
+    gov = Role.query.filter_by(name='Governance').first()
+    if not gov:
+        gov = Role(name='Governance', permissions=permission_objs)
+        db.session.add(gov)
+
+    # Admin user
+    admin = User.query.filter_by(username='admin').first()
+    if not admin:
+        admin = User(username='admin')
+        admin.set_password('admin')
+        admin.roles.append(gov)
+        db.session.add(admin)
+
+    # Risk categories
+    risks = [
+        'Risk Contextualization',
+        'Intelligent Analytics',
+        'High Visibility',
+        'Vulnerability Management',
+        'Real-Time Reporting',
+        'Compliance Management',
+        'Vulnerability Validation Automation',
+    ]
+    for r in risks:
+        if not RiskTag.query.filter_by(name=r).first():
+            db.session.add(RiskTag(name=r))
+
+    db.session.commit()
+    print('Database seeded')


### PR DESCRIPTION
## Summary
- scaffold Flask app with SQLAlchemy models, RBAC decorator and auth blueprint
- add audit views with CSV/PDF export and CLI utilities
- expand audit models with comments, findings, attachments and logs
- provide audit detail UI with status changes, comment and file upload
- improve overall UI with shared styling and card-based templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688e64f05838832f91b37cafcad14a64